### PR TITLE
^++

### DIFF
--- a/lib/modes/command.js
+++ b/lib/modes/command.js
@@ -156,11 +156,14 @@ module.exports = {
 	'/\\^/': function(keys,vim) {
 		this.exec('0');
 		var doc = this.curDoc;
-		var point = doc.find(/(\S)/g);
-		if(point) {
-			doc.cursor.line(point.line);
-			doc.cursor.char(point.char);
-		}
+        if (this.curChar.match(/(\S)/g) === null) {
+            // if the first character is whitespace, seek another
+            var point = doc.find(/(\S)/g);
+            if(point) {
+                doc.cursor.line(point.line);
+                doc.cursor.char(point.char);
+            }
+        }
 	},
 
 


### PR DESCRIPTION
Added fix for ^ when line starts with non-whitespace characters. (Current behavior brings cursor to second character on the line.)
